### PR TITLE
KT-4-add-kafka-transaction-behavior-in-transaction-service

### DIFF
--- a/modules/deposit-service/src/main/java/com/github/tennyros/depositservice/config/KafkaConfig.java
+++ b/modules/deposit-service/src/main/java/com/github/tennyros/depositservice/config/KafkaConfig.java
@@ -30,7 +30,7 @@ public class KafkaConfig {
     }
 
     @Bean
-    public ProducerFactory<String, Object> productFactory(KafkaProperties kafkaProperties) {
+    public ProducerFactory<String, Object> producerFactory(KafkaProperties kafkaProperties) {
         Map<String, Object> conf = new HashMap<>(kafkaProperties.buildProducerProperties());
         return new DefaultKafkaProducerFactory<>(conf);
     }

--- a/modules/deposit-service/src/main/resources/application.yml
+++ b/modules/deposit-service/src/main/resources/application.yml
@@ -8,6 +8,7 @@ spring:
   kafka:
     bootstrap-servers: localhost:9092
     consumer:
+      isolation-level: read_committed
       properties:
         key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
         value.deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer

--- a/modules/transfer-service/src/main/java/com/github/tennyros/transferservice/config/KafkaConfig.java
+++ b/modules/transfer-service/src/main/java/com/github/tennyros/transferservice/config/KafkaConfig.java
@@ -2,10 +2,20 @@ package com.github.tennyros.transferservice.config;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.transaction.KafkaTransactionManager;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 @RequiredArgsConstructor
@@ -13,6 +23,25 @@ import org.springframework.kafka.config.TopicBuilder;
 public class KafkaConfig {
 
     private final KafkaPropertiesConfig kafkaProperties;
+
+    @Bean
+    ProducerFactory<String, Object> producerFactory(KafkaProperties kafkaProperties) {
+        Map<String, Object> conf = new HashMap<>(kafkaProperties.buildProducerProperties());
+        conf.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, kafkaProperties.getProducer().getTransactionIdPrefix());
+        return new DefaultKafkaProducerFactory<>(conf);
+    }
+
+    @Bean
+    KafkaTemplate<String, Object> kafkaTemplate(ProducerFactory<String, Object> producerFactory) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+
+    @Bean
+    KafkaTransactionManager<String, Object> kafkaTransactionManager(
+            ProducerFactory<String, Object> producerFactory) {
+
+        return new KafkaTransactionManager<>(producerFactory);
+    }
 
     @Bean
     NewTopic createWithdrawTopic() {

--- a/modules/transfer-service/src/main/java/com/github/tennyros/transferservice/service/impl/TransferServiceImpl.java
+++ b/modules/transfer-service/src/main/java/com/github/tennyros/transferservice/service/impl/TransferServiceImpl.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import static org.springframework.http.HttpMethod.GET;
@@ -25,6 +26,7 @@ public class TransferServiceImpl implements TransferService {
     private final RestTemplate restTemplate;
 
     @Override
+    @Transactional
     public boolean transfer(TransferRestModel transferRestModel) {
         WithdrawalRequestedEvent withdrawalEvent = eventCreationWithdrawal(transferRestModel);
         DepositRequestedEvent depositEvent = eventCreationDeposit(transferRestModel);

--- a/modules/transfer-service/src/main/resources/application.yml
+++ b/modules/transfer-service/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
       acks: all
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      transaction-id-prefix: transfer-service-${random.value}-
       properties:
         delivery.timeout.ms: 120000
         linger.ms: 0
@@ -25,3 +26,8 @@ app:
       deposit-money: deposit-money-topic
     partitions: 3
     replicas: 3
+
+logging:
+  level:
+    org.springframework.transaction: TRACE
+    org.springframework.kafka.transaction: TRACE

--- a/modules/withdrawal-service/src/main/java/com/github/tennyros/withdrawalservice/config/KafkaConfig.java
+++ b/modules/withdrawal-service/src/main/java/com/github/tennyros/withdrawalservice/config/KafkaConfig.java
@@ -30,7 +30,7 @@ public class KafkaConfig {
     }
 
     @Bean
-    public ProducerFactory<String, Object> productFactory(KafkaProperties kafkaProperties) {
+    public ProducerFactory<String, Object> producerFactory(KafkaProperties kafkaProperties) {
         Map<String, Object> conf = new HashMap<>(kafkaProperties.buildProducerProperties());
         return new DefaultKafkaProducerFactory<>(conf);
     }

--- a/modules/withdrawal-service/src/main/resources/application.yml
+++ b/modules/withdrawal-service/src/main/resources/application.yml
@@ -8,6 +8,7 @@ spring:
   kafka:
     bootstrap-servers: localhost:9092
     consumer:
+      isolation-level: read_committed
       properties:
         key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
         value.deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer


### PR DESCRIPTION
**What was done:**
- added `@Transactional` annotation to the transfer method in transfer-service to enable transactional behavior;
- created `kafkaTemplate` and `kafkaTransactionManager` beans in `KafkaConfig` for handling Kafka transactions;
- configured `producerFactory` bean with transactional id prefix using `kafkaProperties.getProducer().getTransactionIdPrefix()`;
- added logs to track transaction flow and state changes;
- configured `isolation-level: read_committed` in `withdrawal-service` and `deposit-service` consumers to ensure only committed messages are processed;
- renamed `productFactory` beans to `producerFactory` for consistency and readability.

**Why this is needed:**
- `@Transactional` ensures atomicity of the transfer operation, preventing partial writes or data corruption;
- `kafkaTemplate` and `kafkaTransactionManager` are essential for enabling and managing transactional behavior with Kafka producers;
- transactional id prefix configuration allows unique producer transactions per instance, preventing conflicts in a multi-instance setup;
- `read_committed` isolation level ensures consumers in withdrawal-service and deposit-service only read fully committed transactions, preventing data inconsistencies;
- renaming `productFactory` to `producerFactory` improves code clarity and aligns with naming conventions.

**How to test:**
- run transfer-service, withdrawal-service, deposit-service, mock-service and Kafka cluster locally or with Docker;
- trigger a transfer operation and verify the corresponding `withdraw-money-topic` and `deposit-money-topic` receive messages;
- ensure logs display the transaction lifecycle, including begin, commit, and rollback on failures;
- simulate a failure scenario (e.g., throw an exception after sending a withdrawal event) and confirm that the deposit event is not produced;
- verify withdrawal and deposit services only process committed messages by observing log outputs and consumer behavior.

**Links:**
Jira ticket: [KT-4](https://tennyros.atlassian.net/browse/KT-4)

**Testing successful scenario:**

- transaction-service application port:

![transfer-service-port-log](https://github.com/user-attachments/assets/4b00861b-6f8c-44f0-aef2-e30ec5456c17)

- postman post http query with 200 code:

![postman-complete](https://github.com/user-attachments/assets/5ec91305-7dbe-4887-a2aa-f23971714561)

- kafka committed transaction in transfer-service:

![transfer-service-complete-transaction-log](https://github.com/user-attachments/assets/96072d08-9961-485d-b42a-5db6b8b742dd)

- withdrawal-service success event message:

![withdraw-service-complete-topic-log](https://github.com/user-attachments/assets/46ff9347-046f-40c4-a717-96c80ec63f88)

- deposit-service success event message:

![deposit-service-complete-topic-log](https://github.com/user-attachments/assets/156b720e-b6cc-4e87-99cc-30587ecefa83)

**Testing unsuccessful scenario (mock-service is down):**

- postman post http query with 500 code:

![postman-error](https://github.com/user-attachments/assets/f67a9dec-6ee7-4d70-8575-97e49326a35a)

 - kafka rollback transaction in transfer-service:

![transfer-service-error](https://github.com/user-attachments/assets/9069ed1a-c7ac-47cc-8643-06092a52164f)

![transfer-service-error_2](https://github.com/user-attachments/assets/c15ca195-562e-4d79-ae91-28ce89f1205d)






[KT-4]: https://tennyros.atlassian.net/browse/KT-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ