### PR TITLE
KT-5-add-kafka-and-db-operations-in-one-transaction-logic-layer

### DIFF
--- a/modules/transfer-service/pom.xml
+++ b/modules/transfer-service/pom.xml
@@ -39,10 +39,18 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
@@ -70,11 +78,6 @@
 			<artifactId>spring-kafka-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
 	</dependencies>
 
 	<build>

--- a/modules/transfer-service/src/main/java/com/github/tennyros/transferservice/config/KafkaConfig.java
+++ b/modules/transfer-service/src/main/java/com/github/tennyros/transferservice/config/KafkaConfig.java
@@ -1,9 +1,9 @@
 package com.github.tennyros.transferservice.config;
 
+import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +13,7 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.transaction.KafkaTransactionManager;
+import org.springframework.orm.jpa.JpaTransactionManager;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -41,6 +42,11 @@ public class KafkaConfig {
             ProducerFactory<String, Object> producerFactory) {
 
         return new KafkaTransactionManager<>(producerFactory);
+    }
+
+    @Bean("transactionManager")
+    JpaTransactionManager jpaTransactionManager(EntityManagerFactory entityManagerFactory) {
+        return new JpaTransactionManager(entityManagerFactory);
     }
 
     @Bean

--- a/modules/transfer-service/src/main/java/com/github/tennyros/transferservice/persistence/entity/TransferEntity.java
+++ b/modules/transfer-service/src/main/java/com/github/tennyros/transferservice/persistence/entity/TransferEntity.java
@@ -1,0 +1,40 @@
+package com.github.tennyros.transferservice.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "transfers")
+public class TransferEntity implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 6298444750500088465L;
+
+    @Id
+    @Column(nullable = false)
+    private String transferId;
+
+    @Column(nullable = false)
+    private String senderId;
+
+    @Column(nullable = false)
+    private String recipientId;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+}

--- a/modules/transfer-service/src/main/java/com/github/tennyros/transferservice/persistence/repository/TransferRepository.java
+++ b/modules/transfer-service/src/main/java/com/github/tennyros/transferservice/persistence/repository/TransferRepository.java
@@ -1,0 +1,9 @@
+package com.github.tennyros.transferservice.persistence.repository;
+
+import com.github.tennyros.transferservice.persistence.entity.TransferEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TransferRepository extends JpaRepository<TransferEntity, Long> {
+}

--- a/modules/transfer-service/src/main/resources/application.yml
+++ b/modules/transfer-service/src/main/resources/application.yml
@@ -5,6 +5,17 @@ spring:
   application:
     name: transfer-service
 
+  datasource:
+    username: test
+    password: test
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+  h2:
+    console:
+      enabled: true
+
   kafka:
     bootstrap-servers: localhost:9092
     producer:
@@ -29,5 +40,8 @@ app:
 
 logging:
   level:
-    org.springframework.transaction: TRACE
-    org.springframework.kafka.transaction: TRACE
+    org.springframework.transaction: DEBUG
+    org.springframework.orm.jpa.JpaTransactionManager: DEBUG
+    org.apache.kafka.clients.producer.internals.TransactionManager: DEBUG
+    org.springframework.kafka.transaction.KafkaAwareTransactionManager: DEBUG
+


### PR DESCRIPTION
**What was done:**  
- added `JpaTransactionManager` bean in `KafkaConfig` to manage transactions combining JPA and Kafka operations;  
- created `TransferEntity` class with fields `transferId`, `senderId`, `recipientId`, and `amount` representing a transfer operation;  
- implemented `TransferRepository` extending `JpaRepository` to handle persistence of `TransferEntity`;  
- updated `TransferServiceImpl` with entity mapping and saving logic using `BeanUtils.copyProperties`;  
- configured `application.yml` with H2 in-memory database settings and enabled H2 console for debugging;  
- added detailed logging configuration for `JpaTransactionManager` and Kafka transaction managers to track transaction flow.  

**Why this is needed:**  
- `JpaTransactionManager` ensures both JPA and Kafka operations run within a single atomic transaction, preventing partial data persistence and ensuring message consistency;  
- `TransferEntity` and `TransferRepository` enable proper data modeling and storage of transfer details;  
- H2 in-memory setup simplifies local development and testing without external database dependencies;  
- enhanced logging helps monitor transaction lifecycle and debug potential issues in message production and database persistence.  

**How to test:**  
- run `transfer-service` with `application.yml` configuration and H2 console enabled;  
- perform a transfer operation and verify `transfers` table is populated with corresponding records;  
- check logs to ensure transaction starts, commits successfully, or rolls back on failure;  
- simulate a failure (e.g., exception after saving transfer) and ensure no partial data is saved to the database.  

**Links:**  
Jira ticket: [KT-5](https://tennyros.atlassian.net/browse/KT-5)

**Testing successful scenario:**

- transaction-service application port:

![tomcat-port](https://github.com/user-attachments/assets/ca8d1607-d596-4367-8f8a-5a5ada8f8a2b)

- postman post http query with 200 code:

![postman-ok](https://github.com/user-attachments/assets/28efeff4-676d-4186-9729-888b032b7223)

- jpa committed transaction in transfer-service:

![jpa-ok-transaction-1](https://github.com/user-attachments/assets/e2566f2d-ff6c-433e-82a6-3c851ab36ca6)

![jpa-ok-transaction-2](https://github.com/user-attachments/assets/ceb179bd-0385-443b-824c-22ec65ac1bdd)

- kafka committed transaction in transfer-service:

![kafka-ok-transaction](https://github.com/user-attachments/assets/8b024a2a-3dd5-4ac2-a663-4afaf49f971b)

- h2 select query result:

![h2-console-ok](https://github.com/user-attachments/assets/1d6126f6-411a-4e3b-b15b-d92de8a02170)

**Testing unsuccessful scenario (mock-service is down):**

- postman post http query with 500 code:

![postman-error](https://github.com/user-attachments/assets/539df0c8-8790-4682-bbfc-9feb6f48c1bb)

 - jpa rollback transaction in transfer-service:

![jpa-transaction-error](https://github.com/user-attachments/assets/737aa6f9-c216-4f62-aac1-b5a955d786c4)

 - kafka rollback transaction in transfer-service:

![kafka-transaction-error](https://github.com/user-attachments/assets/e1f646ed-1105-4520-8644-94f3332fba64)


[KT-5]: https://tennyros.atlassian.net/browse/KT-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ